### PR TITLE
fixes regexps visibility when checking final webpack config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,6 +25,7 @@ var conf = new webpackConf({
             .iNeedHotDevServer()
             .getConfig();
 
-//console.log('CURRENT CONFIG', JSON.stringify(conf, null, 4));
+/*RegExp.prototype.toJSON = RegExp.prototype.toString;
+console.log('CURRENT CONFIG', JSON.stringify(conf, null, 4));*/
 
 module.exports = conf;


### PR DESCRIPTION
uncomment both lines, regexps are visible now
