### PR TITLE
feat: add paste support for comma-separated tokens

### DIFF
--- a/src/TokenAutocomplete.tsx
+++ b/src/TokenAutocomplete.tsx
@@ -25,6 +25,8 @@ export interface TokenAutocompleteProps {
   onInputChange?: (value: string) => void
   onAdd?: (value: string) => void
   onRemove?: (value: string, index: number) => void
+  /** Separator for splitting pasted text into multiple tokens. Defaults to comma. Set to false to disable. */
+  pasteSeparator?: string | false
   className?: string
   inputClassName?: string
   tokenClassName?: string
@@ -59,6 +61,7 @@ export const TokenAutocomplete = forwardRef<
     onInputChange,
     onAdd,
     onRemove,
+    pasteSeparator,
     className,
     inputClassName,
     tokenClassName,
@@ -84,6 +87,7 @@ export const TokenAutocomplete = forwardRef<
     removeValue,
     focus,
     handleKeyDown,
+    handlePaste,
     handleOptionMouseEnter,
     handleOptionSelect,
     inputRef,
@@ -101,6 +105,7 @@ export const TokenAutocomplete = forwardRef<
     onInputChange,
     onAdd,
     onRemove,
+    pasteSeparator,
   })
 
   // Forward ref to the internal input for react-hook-form focus management
@@ -142,6 +147,7 @@ export const TokenAutocomplete = forwardRef<
           onChange={(e) => setInputValue(e.target.value)}
           onFocus={focus}
           onKeyDown={handleKeyDown}
+          onPaste={handlePaste}
           aria-label={ariaLabel || placeholder || 'Token input'}
         />
       )}

--- a/src/__tests__/TokenAutocomplete.test.tsx
+++ b/src/__tests__/TokenAutocomplete.test.tsx
@@ -403,6 +403,85 @@ describe('TokenAutocomplete', () => {
     })
   })
 
+  describe('paste support', () => {
+    it('splits pasted comma-separated text into tokens', async () => {
+      const user = userEvent.setup()
+      renderComponent()
+      const input = screen.getByTestId('token-input')
+      await user.click(input)
+      await user.paste('alpha, beta, gamma')
+      expect(screen.getAllByTestId('token')).toHaveLength(3)
+    })
+
+    it('trims whitespace from pasted values', async () => {
+      const user = userEvent.setup()
+      const onAdd = vi.fn()
+      renderComponent({ onAdd })
+      const input = screen.getByTestId('token-input')
+      await user.click(input)
+      await user.paste('  alpha ,  beta  ')
+      expect(onAdd).toHaveBeenCalledWith('alpha')
+      expect(onAdd).toHaveBeenCalledWith('beta')
+    })
+
+    it('skips duplicates when pasting', async () => {
+      const user = userEvent.setup()
+      renderComponent({ defaultValues: ['alpha'] })
+      const input = screen.getByTestId('token-input')
+      await user.click(input)
+      await user.paste('alpha, beta')
+      expect(screen.getAllByTestId('token')).toHaveLength(2)
+    })
+
+    it('respects limitToOptions when pasting', async () => {
+      const user = userEvent.setup()
+      renderComponent({ limitToOptions: true })
+      const input = screen.getByTestId('token-input')
+      await user.click(input)
+      await user.paste('alpha, unknown, beta')
+      expect(screen.getAllByTestId('token')).toHaveLength(2)
+    })
+
+    it('applies parseCustom to pasted values', async () => {
+      const user = userEvent.setup()
+      renderComponent({ parseCustom: (v: string) => v.toUpperCase() })
+      const input = screen.getByTestId('token-input')
+      await user.click(input)
+      await user.paste('hello, world')
+      const tokens = screen.getAllByTestId('token')
+      expect(tokens[0]).toHaveTextContent('HELLO')
+      expect(tokens[1]).toHaveTextContent('WORLD')
+    })
+
+    it('allows single value paste without separator (normal behavior)', async () => {
+      const user = userEvent.setup()
+      renderComponent()
+      const input = screen.getByTestId('token-input')
+      await user.click(input)
+      await user.paste('hello')
+      // No comma — should go into the input, not create a token
+      expect(screen.queryByTestId('token')).not.toBeInTheDocument()
+    })
+
+    it('supports custom pasteSeparator', async () => {
+      const user = userEvent.setup()
+      renderComponent({ pasteSeparator: ';' })
+      const input = screen.getByTestId('token-input')
+      await user.click(input)
+      await user.paste('alpha; beta; gamma')
+      expect(screen.getAllByTestId('token')).toHaveLength(3)
+    })
+
+    it('can disable paste splitting with pasteSeparator={false}', async () => {
+      const user = userEvent.setup()
+      renderComponent({ pasteSeparator: false as const })
+      const input = screen.getByTestId('token-input')
+      await user.click(input)
+      await user.paste('alpha, beta')
+      expect(screen.queryByTestId('token')).not.toBeInTheDocument()
+    })
+  })
+
   describe('ref forwarding', () => {
     it('forwards ref to the input element', () => {
       const ref = createRef<HTMLInputElement>()

--- a/src/useTokenAutocomplete.ts
+++ b/src/useTokenAutocomplete.ts
@@ -17,6 +17,8 @@ export interface UseTokenAutocompleteOptions {
   onInputChange?: (value: string) => void
   onAdd?: (value: string) => void
   onRemove?: (value: string, index: number) => void
+  /** Separator for splitting pasted text into multiple tokens. Defaults to comma. Set to false to disable paste splitting. */
+  pasteSeparator?: string | false
 }
 
 export interface UseTokenAutocompleteReturn {
@@ -33,6 +35,7 @@ export interface UseTokenAutocompleteReturn {
   focus: () => void
   blur: () => void
   handleKeyDown: (e: React.KeyboardEvent) => void
+  handlePaste: (e: React.ClipboardEvent) => void
   handleOptionMouseEnter: (value: string) => void
   handleOptionSelect: (value: string) => void
   inputRef: React.RefObject<HTMLInputElement | null>
@@ -52,6 +55,7 @@ export function useTokenAutocomplete({
   onInputChange,
   onAdd,
   onRemove,
+  pasteSeparator = ',',
 }: UseTokenAutocompleteOptions = {}): UseTokenAutocompleteReturn {
   const isControlled = controlledValue !== undefined
   const [internalValues, setInternalValues] = useState<string[]>(defaultValues)
@@ -188,6 +192,34 @@ export function useTokenAutocomplete({
     [addSelectedValue, blur, inputValue, values.length, removeValue, getAvailableOptions],
   )
 
+  const handlePaste = useCallback(
+    (e: React.ClipboardEvent) => {
+      if (pasteSeparator === false) return
+
+      const text = e.clipboardData.getData('text')
+      if (!text.includes(pasteSeparator)) return
+
+      e.preventDefault()
+      const items = text.split(pasteSeparator).map((s) => s.trim()).filter(Boolean)
+      let current = values
+      for (const raw of items) {
+        const item = parseCustom ? parseCustom(raw) : raw
+        if (limitToOptions && !options.includes(item)) continue
+        if (current.includes(item)) continue
+        if (simulateSelect) {
+          current = [item]
+        } else {
+          current = [...current, item]
+        }
+        onAdd?.(item)
+      }
+      updateValues(current)
+      setInputValueState('')
+      setSelectedIndex(0)
+    },
+    [pasteSeparator, values, parseCustom, limitToOptions, options, simulateSelect, updateValues, onAdd],
+  )
+
   const handleOptionMouseEnter = useCallback(
     (value: string) => {
       const opts = getAvailableOptions()
@@ -237,6 +269,7 @@ export function useTokenAutocomplete({
     focus,
     blur,
     handleKeyDown,
+    handlePaste,
     handleOptionMouseEnter,
     handleOptionSelect,
     inputRef,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,6 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: ['src/__tests__/setup.ts'],
     globals: true,
-    exclude: ['e2e/**', 'node_modules/**'],
+    exclude: ['e2e/**', 'node_modules/**', '.claude/**'],
   },
 })


### PR DESCRIPTION
## Summary
- Adds paste support: comma-separated text pasted into the input is automatically split into individual tokens
- Configurable via `pasteSeparator` prop (defaults to `","`, set to `false` to disable)
- Respects `limitToOptions`, `parseCustom`, and duplicate prevention
- Also excludes `.claude/` from vitest config to avoid worktree interference

Closes #14

## Test plan
- [x] Pasting comma-separated text creates multiple tokens
- [x] Whitespace is trimmed from pasted values
- [x] Duplicate tokens are skipped
- [x] `limitToOptions` is respected
- [x] `parseCustom` is applied to each pasted value
- [x] Single value paste (no separator) falls through to normal input behavior
- [x] Custom `pasteSeparator` works
- [x] `pasteSeparator={false}` disables the feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)